### PR TITLE
build with -DZOSLIB_OVERRIDE_CLIB for creat()

### DIFF
--- a/patches/build.gen.py.patch
+++ b/patches/build.gen.py.patch
@@ -1,0 +1,12 @@
+diff --git a/build/gen.py b/build/gen.py
+index adb622a9..1b3558fe 100755
+--- a/build/gen.py
++++ b/build/gen.py
+@@ -509,6 +509,7 @@ def WriteGNNinja(path, platform, host, options, args_list):
+       cflags.append('-Wno-unused-function')
+       cflags.append('-D_OPEN_SYS_FILE_EXT')
+       cflags.append('-DPATH_MAX=1024')
++      cflags.append('-DZOSLIB_OVERRIDE_CLIB')
+ 
+     if platform.is_posix() and not platform.is_haiku():
+       ldflags.append('-pthread')


### PR DESCRIPTION
The (new) overridden creat() in zoslib creates a file as ISO8859-1 and tags it, so user no longer has to chtag the generated build files manually, as was previously instructed in the [initial z/OS port](https://gn.googlesource.com/gn/+/45aa842fb41d79e149b46fac8ad71728856e15b9).

Note that GN build currently fails on z/OS - pending recent PRs in internal zoslib yet to be promoted to ibmruntimes/ (resolve warnings now treated as errors by GN, resolve a pause followed by garbage emitted in V8's gn run, overrides creat(), etc.).

The only file that will be tagged as mixed binary and text in V8's gn-generated files is toolchain.ninja (`m ISO8859-1` instead of `t ISO8859-1`), because of the `std::ios_base::binary` in [NinjaToolchainWriter::RunAndWriteFile's std::ofstream open()](https://gn.googlesource.com/gn/+/refs/heads/main/src/gn/ninja_toolchain_writer.cc#72). However, zopen's vim, grep and ninja can still read it fine, so I left this change out:
```
+#if !defined(OS_ZOS)
   file.open(FilePathToUTF8(ninja_file).c_str(),
             std::ios_base::out | std::ios_base::binary);
+#else
+  file.open(FilePathToUTF8(ninja_file).c_str(), std::ios_base::out);
+#endif
```