### PR TITLE
build with -Wno-unknown-pragmas

### DIFF
--- a/patches/build.gen.py.patch
+++ b/patches/build.gen.py.patch
@@ -1,8 +1,18 @@
 diff --git a/build/gen.py b/build/gen.py
-index adb622a9..1b3558fe 100755
+index 232e5363..b5020b15 100755
 --- a/build/gen.py
 +++ b/build/gen.py
-@@ -509,6 +509,7 @@ def WriteGNNinja(path, platform, host, options, args_list):
+@@ -469,6 +469,9 @@ def WriteGNNinja(path, platform, host, options, args_list):
+         '-std=c++17'
+     ])
+ 
++    if platform.is_zos():
++      cflags.extend(['-Wno-unknown-pragmas'])
++
+     # flags not supported by gcc/g++.
+     if cxx == 'clang++':
+       cflags.extend(['-Wrange-loop-analysis', '-Wextra-semi-stmt'])
+@@ -511,6 +514,7 @@ def WriteGNNinja(path, platform, host, options, args_list):
        cflags.append('-Wno-unused-function')
        cflags.append('-D_OPEN_SYS_FILE_EXT')
        cflags.append('-DPATH_MAX=1024')


### PR DESCRIPTION
This is to prevent warnings on pragmas that currently aren't supported by ibm-clang; otherwise the `-Wall` along with `-Werror` used by GN will cause the build to fail.

The change to build/gen.py applies as of a pull of GN today, at commit 85944ebc24a90ec1e489e85a46fdc68542c3146f.