### PR TITLE
update configure and add cleanup and install and adjust zoslib paths

### DIFF
--- a/buildenv
+++ b/buildenv
@@ -21,6 +21,9 @@ export ZOPEN_RUNTIME_DEPS="bash"
 export ZOPEN_CATEGORIES="development"
 export ZOPEN_COMP=CLANG
 
+export ZOPEN_CLEAN="zopen_cleanup"
+export ZOPEN_INSTALL="zopen_install"
+
 # These settings are for specifying custom build 
 # types other than configure and make.
 ZOPEN_CONFIGURE="zopen_configure"
@@ -29,8 +32,7 @@ ZOPEN_CHECK="zopen_check"
 
 
 zopen_configure() {
- # ORIG IGOR  python3 build/gen.py --zoslib-dir `pwd`/third_party/zoslib
-  python build/gen.py --zoslib-dir $HOME/zopen/dev/zoslibport/zoslib
+  python build/gen.py --zoslib-dir ${ZOSLIB_HOME} --link-lib="$LIBS"
 }
 zopen_build() {
   ninja -C out -j $ZOPEN_NUM_JOBS -v
@@ -38,7 +40,11 @@ zopen_build() {
 zopen_check() {
   ./out/gn_unittests
 }
-
+zopen_install() {
+  rm -rf ${ZOPEN_INSTALL_DIR}
+  mkdir -p ${ZOPEN_INSTALL_DIR}
+  cp -pR out/* ${ZOPEN_INSTALL_DIR}
+}
 
 zopen_check_results()
 {

--- a/patches/build.gen.py.patch
+++ b/patches/build.gen.py.patch
@@ -1,9 +1,20 @@
 diff --git a/build/gen.py b/build/gen.py
-index 232e5363..b5020b15 100755
+index 07b699b0..f17d247e 100755
 --- a/build/gen.py
 +++ b/build/gen.py
+@@ -201,8 +201,8 @@ def main(argv):
+                       default='../third_party/zoslib',
+                       dest='zoslib_dir',
+                       help=('Specify the path of ZOSLIB directory, to link ' +
+-                            'with <ZOSLIB_DIR>/install/lib/libzoslib.a, and ' +
+-                            'add -I<ZOSLIB_DIR>/install/include to the compile ' +
++                            'with <ZOSLIB_DIR>/lib/libzoslib.a, and ' +
++                            'add -I<ZOSLIB_DIR>/include to the compile ' +
+                             'commands. See README.md for details.'))
+ 
+   args_list.add_to_parser(parser)
 @@ -469,6 +469,9 @@ def WriteGNNinja(path, platform, host, options, args_list):
-         '-std=c++17'
+         '-std=c++20'
      ])
  
 +    if platform.is_zos():
@@ -20,3 +31,12 @@ index 232e5363..b5020b15 100755
  
      if platform.is_posix() and not platform.is_haiku():
        ldflags.append('-pthread')
+@@ -869,7 +873,7 @@ def WriteGNNinja(path, platform, host, options, args_list):
+     ])
+ 
+   if platform.is_zos():
+-    libs.extend([ options.zoslib_dir + '/install/lib/libzoslib.a' ])
++    libs.extend([ options.zoslib_dir + '/lib/libzoslib.a' ])
+ 
+   if platform.is_windows():
+     static_libraries['base']['sources'].extend([


### PR DESCRIPTION
- update configure and add cleanup to support `zopen build -f` and install
- adjust zoslib paths to conform with zopen build env and include previous commits https://github.com/ZOSOpenTools/gnport/commit/9d4cc7cdb7a66657731ec411f3f3d432bda51aa4 and https://github.com/ZOSOpenTools/gnport/commit/92eacd1aeb56febf574b9396e0650d47e4934e0f.

The patch applies as of today's pull of GN's [commit](https://gn.googlesource.com/gn/+/b5adfe5f574d7110b80feb9aae6fae97c366840b).